### PR TITLE
#161216329: Fix correct route bug 

### DIFF
--- a/client/src/routes/AuthRoute.jsx
+++ b/client/src/routes/AuthRoute.jsx
@@ -1,0 +1,21 @@
+
+import React from 'react';
+import { Route, Redirect } from 'react-router-dom';
+import SignInContainer from '../modules/Auth/container';
+
+const isLoggedIn = () => localStorage.getItem('aTeamsToken') &&
+    localStorage.getItem('userId') &&
+    localStorage.getItem('role');
+
+const AuthRoute = (props) => (
+  <Route
+    {...props}
+    render={(renderProps) => (isLoggedIn() ?
+      <Redirect to="/teams" /> :
+      <SignInContainer {...renderProps} />)}
+  />
+);
+
+
+export default AuthRoute;
+

--- a/client/src/routes/index.jsx
+++ b/client/src/routes/index.jsx
@@ -7,8 +7,8 @@ import 'react-toastify/dist/ReactToastify.css';
 import Favorite from '../modules/Teams/components/FavoriteTeams';
 import Home from '../modules/Home/container';
 import Preloader from '../modules/common/Preloader';
-import SignIn from '../modules/Auth/container';
-import CreateTeam from '../modules/CreateTeam/container';
+import AuthRoute from './AuthRoute';
+import CreateTeamContainer from '../modules/CreateTeam/container';
 import Teams from '../modules/Teams/container';
 import RequireAuth from './RequireAuth';
 
@@ -31,8 +31,8 @@ export default class Routes extends Component {
           <Switch>
             <Route path="/teams/favorites" exact component={RequireAuth(Favorite)} />
             <Route path="/teams" exact component={Home} />
-            <Route path="/" exact component={SignIn} />
-            <Route path="/teams/create" component={RequireAuth(CreateTeam)} />
+            <AuthRoute />
+            <Route path="/teams/create" component={RequireAuth(CreateTeamContainer)} />
             <Route path="/teams/:id" exact component={RequireAuth(Teams)} />
           </Switch>
         </React.Fragment>

--- a/client/src/tests/__mocks__/mockLocalStorage.js
+++ b/client/src/tests/__mocks__/mockLocalStorage.js
@@ -7,4 +7,8 @@ export default {
   removeItem(key) {
    return delete localStorage[key]; //eslint-disable-line
   },
+
+  getItem(key) {
+    return localStorage[key];
+  }
 };

--- a/client/src/tests/routes/AuthRoute.test.jsx
+++ b/client/src/tests/routes/AuthRoute.test.jsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { shallow } from "enzyme";
+import { Route, Redirect } from 'react-router-dom';
+import AuthRoute from "../../../src/routes/AuthRoute";
+import mockLocalStorage from '../__mocks__/mockLocalStorage';
+import SignInComponent from '../../modules/Auth/container';
+
+global.localStorage = mockLocalStorage;
+
+const getShallow = (props = {}) => shallow(<AuthRoute {...props} />);
+
+describe('Testing AuthRoute Route type', () => {
+  describe('components rendered', () => {
+    it('should match snapShot', () => {
+      const shallowObj = getShallow();
+      expect(shallowObj).toMatchSnapshot();
+    });
+
+    it('should always render a Route component', () => {
+      const shallowObj = getShallow();
+      expect(shallowObj.find(Route)
+        .length).toBe(1);
+    });
+
+
+    it('should render a SignIn component when user is not logged in', () => {
+      global.localStorage.setItem('userId', '');
+      global.localStorage.setItem('role', '');
+      global.localStorage.setItem('aTeamsToken', '');
+      const shallowObj = getShallow();
+      expect(shallowObj.find(Route)
+        .length).toBe(1);
+      const renderFn = shallowObj.find(Route)
+        .prop('render');
+      const renderedComponent = renderFn();
+      expect(renderedComponent.type)
+        .toBe(SignInComponent);
+    });
+    it('should render a Redirect when the user is logged in', () => {
+      global.localStorage.setItem('userId', 'mock-user-id');
+      global.localStorage.setItem('role', 'member');
+      global.localStorage.setItem('aTeamsToken', 'mock-team-toke');
+      const shallowObj = getShallow();
+      expect(shallowObj.find(Route)
+        .length).toBe(1);
+      const renderFn = shallowObj.find(Route)
+        .prop('render');
+      const renderedComponent = renderFn();
+      expect(renderedComponent.type)
+        .toBe(Redirect);
+    });
+  });
+});
+

--- a/jest.config.js
+++ b/jest.config.js
@@ -11,14 +11,14 @@ module.exports = {
   ],
   'moduleNameMapper': {
     '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$': '<rootDir>/client/src/tests/__mocks__/assetsTransformer.js',
-    '\\.(css|less|scss)$': '<rootDir>/client/src/tests/__mocks__/assetsTransformer.js',
+    '\\.(css|less|scss)$': '<rootDir>/client/src/tests/__mocks__/assetsTransformer.js'
   },
   'collectCoverage': true,
-  'collectCoverageFrom': ["client/src/**/*.jsx", "client/src/redux/**/*.js"],
+  'collectCoverageFrom': ["client/src/**/*.{js,jsx}"],
   'testPathIgnorePatterns': [
-    '<rootDir>/client/src/tests/__mocks__',
+    '<rootDir>/client/src/tests/__mocks__'
   ],
-  'coveragePathIgnorePatterns': ['/node_modules', '<rootDir>/client/src/index.tsx', `'<rootDir>/client/src/tests'`],
+  'coveragePathIgnorePatterns': ['/node_modules', '<rootDir>/client/src/index.tsx', '<rootDir>/client/src/tests'],
   'snapshotSerializers': ['enzyme-to-json/serializer'],
   'setupTestFrameworkScriptFile': '<rootDir>/client/src/setupEnzyme.js'
 };


### PR DESCRIPTION
#### What does this PR do?
- adds AuthRoute Route type
- routes logged-in users to '/teams'
- adds tests for the AuthRoute
- ensures that tests added have 100% coverage
- updates mockLocalStorage to have a getItem method

#### Description of Task to be completed?
- logged-in users should be redirected to `/teams` when they manually route to `/`

#### How should this be manually tested?
- once user is logged in and manually routes to `/`, the user is taken back to `/teams`

#### Any background context you want to provide?
- users can currently manually route to the login page even after they are logged-in

#### What are the relevant pivotal tracker stories?
#161216329

#### Screenshots or gifs (if appropriate)
- none

#### Questions:
- none
