### PR TITLE
#161257375 Implement redesign of add integration popup

### DIFF
--- a/client/src/modules/Teams/components/Account.jsx
+++ b/client/src/modules/Teams/components/Account.jsx
@@ -2,6 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import ReactTooltip from 'react-tooltip';
 import AddIntegrationModal from '../../common/Modals/AddIntegration';
+import pt from '../../../../public/resources/images/pt.png';
+import github from '../../../../public/resources/images/github.png';
+import slack from '../../../../public/resources/images/slack.png';
 
 
 class Account extends React.Component {
@@ -66,15 +69,9 @@ class Account extends React.Component {
             closeModal={this.onCloseModal}
           />
           <div className={`col ${contentWidth} integration-row`}>
-            <i className="material-icons integration-icons">
-                group_add
-            </i>
-            <i className="material-icons integration-icons">
-            sync
-            </i>
-            <i className="material-icons integration-icons">
-            pie_chart
-            </i>
+            <img className="integration-icons" src={github} alt="github" />
+            <img className="integration-icons" src={slack} alt="github" />
+            <img className="integration-icons" src={pt} alt="github" />
             <h6 className="integration-h6">Track your teams with additional data</h6>
             <button
               onClick={this.onOpenModal}

--- a/client/src/modules/common/Modals/AddIntegration.jsx
+++ b/client/src/modules/common/Modals/AddIntegration.jsx
@@ -1,38 +1,64 @@
 import React from 'react';
 import Modal from 'react-modal';
 import PropTypes from 'prop-types';
+import github from '../../../../public/resources/images/github.png';
+import pt from '../../../../public/resources/images/pt.png';
+import slack from '../../../../public/resources/images/slack.png';
 
-
-const customStyles = {
-  content: {
-    top: '50%',
-    left: '50%',
-    right: 'auto',
-    bottom: 'auto',
-    marginRight: '-50%',
-    width: '30%',
-    height: '50%',
-    transform: 'translate(-50%, -50%)',
-    background: '#3359DB',
-    color: '#fff',
-    cursor: 'pointer'
-  }
-};
-
-Modal.setAppElement('#app');
 
 const AddIntegration = ({ isModalOpen, closeModal }) => (
   <Modal
     isOpen={isModalOpen}
     contentLabel="Add Integration"
+    ariaHideApp={false}
+    overlayClassName="message-overlay"
     onRequestClose={closeModal}
-    style={customStyles}
+    className="modalStyle integration-modal"
+    // style={customStyles}
   >
-    <p className="integration-header">Select an integration to add</p>
-    <p className="integration-tools">Github Repo</p>
-    <p className="integration-tools">Pivotal Tracker</p>
-    <p className="integration-tools">Slack Channel (private)</p>
-    <p className="integration-tools">Slack Channel (public)</p>
+    <div>
+      <header className="integration-header">
+        <h5>Add an Integration</h5>
+      </header>
+      <section className="integration-body">
+        <p className="">Select an integration to add</p>
+        <div className="integration-tools-container">
+          <div className="integration-tools">
+            <div className="integration-tool-name">
+              <img className="integration-tool-icon" src={github} alt="git" />
+              <p className="">Github Repository</p>
+            </div>
+            <i className="fas fa-greater-than" />
+          </div>
+          <div className="integration-tools">
+            <div className="integration-tool-name">
+              <img className="integration-tool-icon" src={pt} alt="git" />
+              <p className="">Pivotal Tracker</p>
+            </div>
+            <i className="fas fa-greater-than" />
+          </div>
+          <div className="integration-tools">
+            <div className="integration-tool-name">
+              <img className="integration-tool-icon" src={slack} alt="git" />
+              <p className="">Slack Channel (private)</p>
+            </div>
+            <i className="fas fa-greater-than" />
+          </div>
+          <div className="integration-tools no-border">
+            <div className="integration-tool-name">
+              <img className="integration-tool-icon" src={slack} alt="git" />
+              <p className="">Slack Channel (public)</p>
+            </div>
+            <i className="fas fa-greater-than" />
+          </div>
+        </div>
+
+      </section>
+      <footer onClick={() => closeModal()} className="integration-tool-footer">
+        <p>cancel</p>
+      </footer>
+
+    </div>
   </Modal>
 );
 

--- a/client/src/tests/modules/common/modals/addIntegration.test.js
+++ b/client/src/tests/modules/common/modals/addIntegration.test.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import AddIntegration from '../../../../modules/common/Modals/AddIntegration';
+
+describe('Add Integration Modal', () => {
+  const props = {
+    isModalOpen: false,
+    closeModal: jest.fn()
+  };
+
+  it('renders properly', () => {
+    const AddIntegrationWrapper = shallow(<AddIntegration {...props} />);
+    expect(AddIntegrationWrapper.exists()).toBeTruthy();
+  });
+
+  it('should close the modal when cancel button is clicked', () => {
+    const AddIntegrationWrapper = shallow(<AddIntegration {...props} />);
+    AddIntegrationWrapper.find('.integration-tool-footer').simulate('click');
+    expect(props.closeModal).toHaveBeenCalled();
+  });
+});

--- a/client/styles/components/_teams.scss
+++ b/client/styles/components/_teams.scss
@@ -20,8 +20,7 @@
 
 .integration-icons {
   margin-right: 20px;
-  color: $andela-blue;
-  font-size: 35px;
+  width: 40px;
 }
 
 .integration-h6 {
@@ -49,16 +48,66 @@
 }
 
 .integration-tools {
-  border-block-end: inherit;
-  margin-top: 20px;
-  padding-bottom: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid #DDDDDD;
+  padding: 11px 10px;
   font-family: 'Lato';
 }
 
+.integration-modal {
+  padding: 0 !important;
+  width: 29% !important;
+}
+
 .integration-header {
-  text-align: center;
-  font-size: 14px;
+  text-align: left;
   font-family: 'Lato';
+  padding: 15px;
+
+  h5 {
+    font-size: 18px;
+  }
+}
+
+.no-border {
+  border: none;
+}
+
+.integration-tool-name {
+  display: flex;
+  align-items: center;
+}
+
+.integration-body {
+  padding: 15px 29px;
+  border-bottom: 1px solid #DDDDDD;
+  border-top: 1px solid #DDDDDD;
+}
+
+.integration-tool-icon {
+  width: 35px;
+  height: 35px;
+  margin-right: 12px;
+}
+
+.integration-tools-container {
+  background-color: #F7F6F6;
+  padding: 0px 6px;
+
+}
+
+.integration-tool-footer {
+  display: flex;
+  justify-content: flex-end;
+  padding: 11px 29px;
+  cursor: pointer;
+
+  p {
+    font-size: 16px;
+    text-transform: capitalize;
+  }
 }
 
 .sidebar {


### PR DESCRIPTION
#### What does this PR do?
- Improve add-integration popup interface

#### Description of Task to be completed?
- Implement redesign of add integration popup
- add icons to integration tools

#### How should this be manually tested?
- Login to the [review app](https://ghoulies-taps-client-pr-45.herokuapp.com/)
- Click `VIEW TEAM` on any card item
- Click `Account` on the navigation bar
- Click `Add an integration` button at the centre of the page

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
[#161257375](https://www.pivotaltracker.com/story/show/161257375)
#### Screenshots (if appropriate)
<img width="1431" alt="screen shot 2018-10-17 at 4 16 31 pm" src="https://user-images.githubusercontent.com/23261181/47096894-105f3580-d228-11e8-833b-4733b0e940b6.png">

#### Questions:
