### PR TITLE
#161223150 Create admin request page

### DIFF
--- a/client/src/modules/Admin/components/AdminRequest.jsx
+++ b/client/src/modules/Admin/components/AdminRequest.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+// components
+import withRequests from '../../HOC/withRequests';
+import RequestHolder from './RequestHolder';
+import RequestPagination from '../../common/Pagination';
+
+// mock data
+import requests from '../../../tests/modules/Admin/mock/mockData';
+
+
+export const Request = ({
+  headerText,
+  handleChange,
+  requests,
+  checkedAll
+}) => (
+  <div className="request-container text-blue">
+    <h4>{headerText}</h4>
+    <hr className="hr-top" />
+    <RequestHolder
+      handleChange={handleChange}
+      requests={requests}
+      checkedAll={checkedAll}
+    />
+    <RequestPagination />
+
+    <div className="admin-btn-holder">
+      <button className="btn blue-btn admin-btn-margin" type="button">Accept</button>
+      <button className="btn red-btn" type="button">Reject</button>
+    </div>
+
+  </div>
+);
+
+Request.propTypes = {
+  headerText: PropTypes.string.isRequired,
+  handleChange: PropTypes.func.isRequired,
+  requests: PropTypes.array.isRequired,
+  checkedAll: PropTypes.bool.isRequired
+};
+
+const AdminRequests = withRequests(Request, {
+  requests: requests.data.requests,
+  pageTitle: 'Admin Requests'
+});
+
+export default AdminRequests;

--- a/client/src/modules/Admin/components/RequestCheckbox.jsx
+++ b/client/src/modules/Admin/components/RequestCheckbox.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+const RequestCheckbox = ({
+  handleChange,
+  checkOne,
+  requests = [],
+  checkedAll
+}) => {
+  const Requests = requests.map((request, index) => (
+    <p key={request.id}>
+      <label htmlFor={request.id}>
+        <input
+          name={request.id}
+          id={request.id}
+          type="checkbox"
+          className="filled-in"
+          onChange={(e) => handleChange(e, request)}
+          checked={request.checked}
+        />
+        <span>{`${request.user.displayName} < ${request.user.email} >`}</span>
+      </label>
+    </p>));
+
+  return Requests;
+};
+
+export default RequestCheckbox;

--- a/client/src/modules/Admin/components/RequestHolder.jsx
+++ b/client/src/modules/Admin/components/RequestHolder.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+// component
+import RequestCheckbox from './RequestCheckbox';
+
+const RequestHolder = ({
+  handleChange,
+  requests,
+  checkedAll
+}) => (
+  <div className="request-checkbox-container">
+    <form>
+      <p>
+        <label htmlFor="main-control">
+          <input
+            name="main-control"
+            id="main-control"
+            type="checkbox"
+            className="filled-in"
+            onChange={(e) => handleChange(e)}
+            checked={checkedAll}
+          />
+          <span>Mark All</span>
+        </label>
+      </p>
+      <hr />
+      {/* hold the requests */}
+      <RequestCheckbox
+        handleChange={handleChange}
+        requests={requests}
+        checkedAll={checkedAll}
+      />
+    </form>
+  </div>
+);
+
+RequestHolder.propTypes = {
+  handleChange: PropTypes.func.isRequired,
+  requests: PropTypes.array.isRequired,
+  checkedAll: PropTypes.bool.isRequired
+};
+
+export default RequestHolder;

--- a/client/src/modules/HOC/withRequests.jsx
+++ b/client/src/modules/HOC/withRequests.jsx
@@ -1,0 +1,90 @@
+import React, { Component, Fragment } from 'react';
+
+// components
+import Navbar from '../common/Navbar';
+
+const withRequests = (WrappedComponent, data) => {
+  class ComponentWithData extends Component {
+    constructor(props) {
+      super(props);
+
+      this.state = {
+        checkAll: false
+      };
+
+      this.handleInputChange = this.handleInputChange.bind(this);
+    }
+
+    componentDidMount() {
+      this.addCheckedFieldToRequests(data.requests);
+    }
+
+    handleInputChange(event, request) {
+      const { target } = event;
+      const { name, checked } = target;
+
+      /**to check if the mark all button was clicked
+       * then change the checked field of all the requests
+      */
+      if (name === 'main-control') {
+        return this.setState(previousState => {
+          const updatedRequests = previousState.allRequests
+            .map(request => ({ ...request, checked }));
+
+          return {
+            ...previousState,
+            checkAll: !previousState.checkAll,
+            allRequests: updatedRequests
+          };
+        });
+      }
+
+      /**
+       * this will handle when a single request is
+       * selected and change the state of the mark all button
+       */
+      return this.setState(previousState => {
+        const updatedRequest = previousState.allRequests
+          .map(previousRequest => ((previousRequest.id === request.id) ?
+            { ...previousRequest, checked } : previousRequest));
+
+        return {
+          ...previousState,
+          checkAll: false,
+          allRequests: updatedRequest
+        };
+      });
+    }
+
+    addCheckedFieldToRequests(requests) {
+      // take all the requests map through and add checked field
+      const requestsWithCheckedField = requests
+        .map(request => ({ ...request, checked: false }));
+
+      return this.setState({
+        ...this.state,
+        allRequests: requestsWithCheckedField
+      });
+    }
+
+    render() {
+      const { checkBoxes, checkAll, allRequests } = this.state;
+      return (
+        <Fragment>
+          <Navbar />
+          <WrappedComponent
+            headerText={data.pageTitle}
+            handleChange={this.handleInputChange}
+            checkOne={checkBoxes}
+            requests={allRequests}
+            checkedAll={checkAll}
+          />
+        </Fragment>
+      );
+    }
+  }
+
+  return ComponentWithData;
+};
+
+export default withRequests;

--- a/client/src/modules/common/Navbar/index.jsx
+++ b/client/src/modules/common/Navbar/index.jsx
@@ -35,7 +35,8 @@ class Navbar extends Component {
     this.state = {
       showSearchBar: false,
       name: '',
-      timeout: 0
+      timeout: 0,
+      noOfRequests: 5
     };
     this.toggleState = this.toggleState.bind(this);
     this.handleSearch = this.handleSearch.bind(this);
@@ -191,13 +192,13 @@ class Navbar extends Component {
                 </NavLink>
               </li>
               <li className="notif-container">
-                <a href="#!">
+                <NavLink to="/requests/admin">
                   {/* Notifications */}
-                  <span className="notif-badge" />
+                  <span className="badge notif-badge">{this.state.noOfRequests}</span>
                   <i className="material-icons" data-tip="notifications">
                     notifications_active
                   </i>
-                </a>
+                </NavLink>
               </li>
               <li>
                 <a

--- a/client/src/modules/common/Pagination/index.jsx
+++ b/client/src/modules/common/Pagination/index.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { Pagination } from 'semantic-ui-react';
+
+const RequestPagination = () => (
+  <Pagination
+    defaultActivePage={1}
+    firstItem={null}
+    lastItem={null}
+    pointing
+    secondary
+    totalPages={10}
+  />
+);
+
+export default RequestPagination;

--- a/client/src/routes/index.jsx
+++ b/client/src/routes/index.jsx
@@ -12,6 +12,7 @@ import Teams from '../modules/Teams/container';
 import RequireAuth from './RequireAuth';
 import AuthRoute from './AuthRoute';
 import ErrorPage from '../modules/common/404';
+import AdminRequests from '../modules/Admin/components/AdminRequest';
 
 export default class Routes extends Component {
   componentDidMount() {
@@ -35,6 +36,7 @@ export default class Routes extends Component {
             <Route path="/teams/create" component={RequireAuth(CreateTeam)} />
             <AuthRoute path="/" exact component={SignInContainer} />
             <Route path="/teams/:id" exact component={RequireAuth(Teams)} />
+            <Route path="/requests/admin" exact component={RequireAuth(AdminRequests)} />
             <Route path="/404" exact component={ErrorPage} />
             <Redirect from="*" to="/404" />
           </Switch>

--- a/client/src/tests/modules/Admin/components/AdminRequests.test.jsx
+++ b/client/src/tests/modules/Admin/components/AdminRequests.test.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import AdminRequests, { Request } from '../../../../modules/Admin/components/AdminRequest';
+
+import requests from '../mock/mockData';
+
+describe('Test for AdminRequests component', () => {
+  const handleChange = jest.fn();
+
+  let props = {
+    handleChange,
+    requests: requests.data.requests
+  };
+
+  let WrapperComponent = shallow(<AdminRequests {...props} />);
+
+  it('should render properly', () => {
+    expect(true).toBe(true);
+    expect(WrapperComponent.length).toBe(1);
+  });
+});
+
+describe('Test for Request component', () => {
+  const WrapperComponent = shallow(<Request />);
+
+  it('should render properly', () => {
+    expect(WrapperComponent.length).toBe(1);
+  });
+});

--- a/client/src/tests/modules/Admin/components/RequestCheckbox.test.jsx
+++ b/client/src/tests/modules/Admin/components/RequestCheckbox.test.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import RequestCheckbox from '../../../../modules/Admin/components/RequestCheckbox';
+
+import requests from '../mock/mockData';
+
+describe('Test for RequestCheckbox component', () => {
+  const handleChange = jest.fn();
+
+  let props = {
+    handleChange,
+    requests: requests.data.requests
+  };
+
+  let WrapperComponent = shallow(<RequestCheckbox {...props} />);
+
+  it('should render properly', () => {
+    expect(WrapperComponent.length).toBe(props.requests.length);
+  });
+
+  it('should render checkbox with the requests', () => {
+    expect(WrapperComponent.find('input').get(0).props.type).toBe('checkbox');
+
+    expect(WrapperComponent.find('input').get(0).props.id).toBe(props.requests[0].id);
+  });
+
+  it('should call the onChange event listener', () => {
+    WrapperComponent.find('input').get(0).props.onChange();
+
+    expect(WrapperComponent.find('input').get(0).props.type).toBe('checkbox');
+  });
+
+  it('should render properly with no requests', () => {
+    props = {
+      handleChange,
+    };
+
+    WrapperComponent = shallow(<RequestCheckbox {...props} />);
+
+    expect(WrapperComponent.length).toBe(0);
+  });
+});
+

--- a/client/src/tests/modules/Admin/components/RequestHolder.test.jsx
+++ b/client/src/tests/modules/Admin/components/RequestHolder.test.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import RequestHolder from '../../../../modules/Admin/components/RequestHolder';
+
+describe('Test for RequestHolder component', () => {
+  const handleChange = jest.fn();
+
+  const WrapperComponent = shallow(<RequestHolder handleChange={handleChange} />);
+
+  it('should render properly', () => {
+    expect(WrapperComponent.find('.request-checkbox-container').length).toBe(1);
+  });
+
+  it('should call the change event', () => {
+    expect(true).toBe(true);
+
+    WrapperComponent.find('#main-control').simulate('change');
+
+    expect(WrapperComponent.find('#main-control').length).toBe(1);
+  });
+});
+

--- a/client/src/tests/modules/Admin/mock/mockData.js
+++ b/client/src/tests/modules/Admin/mock/mockData.js
@@ -1,0 +1,157 @@
+const adminRequests = {
+  "data": {
+    "requests": [
+      {
+        "id": "977a7d2d-b30a-4669-89d0-46e5151380b2",
+        "userId": "76e999da-31b0-4f5e-ba34-b66bc58b93f1",
+        "teamId": null,
+        "type": "admin_request",
+        "data": null,
+        "createdAt": "2018-10-17T09:39:02.616Z",
+        "updatedAt": "2018-10-17T09:39:02.616Z",
+        "user": {
+          "id": "76e999da-31b0-4f5e-ba34-b66bc58b93f1",
+          "blocked": false,
+          "displayName": "Jacob",
+          "email": "jacob.nouwatin@andela.com",
+          "githubUsername": "nouwatinjacob",
+          "googleId": "107115925180426618809",
+          "photo": "https://lh5.googleusercontent.com/-2Xmwd62r3aw/AAAAAAAAAAI/AAAAAAAAABk/Ich0bYU4tI8/s96-c/photo.jpg",
+          "role": "admin",
+          "slackId": "123456",
+          "verified": false,
+          "createdAt": "2018-10-07T12:11:28.974Z",
+          "updatedAt": "2018-10-07T12:11:28.974Z"
+        }
+      },
+      {
+        "id": "3f78fc72-0635-4044d-a4df-f5c87d29bc9a",
+        "userId": "ac568e4b-fdaa-4925-9d48-50fa0c755f7f",
+        "teamId": null,
+        "type": "admin_request",
+        "data": null,
+        "createdAt": "2018-10-16T13:00:30.043Z",
+        "updatedAt": "2018-10-16T13:00:30.043Z",
+        "user": {
+          "id": "ac568e4b-fdaa-4925-9d48-50fa0c755f7f",
+          "blocked": false,
+          "displayName": "Oguejiofor",
+          "email": "oguejiofor.chidiebere@andela.com",
+          "githubUsername": "prof",
+          "googleId": "112154402615555847666",
+          "photo": "https://lh3.googleusercontent.com/-QToLxIFrSmw/AAAAAAAAAAI/AAAAAAAAAAA/AAN31DVd-VxKZmompi6oltuKrQkpbJNxyQ/s96-c/photo.jpg",
+          "role": "member",
+          "slackId": "4354545454",
+          "verified": false,
+          "createdAt": "2018-10-16T12:20:38.914Z",
+          "updatedAt": "2018-10-16T12:20:38.914Z"
+        }
+      },
+      {
+        "id": "87ffd2b5-e83394-4312-ae3b-f1060bf386d0",
+        "userId": "3dee1006-c5e0-42dc-97f5-774729e571dc",
+        "teamId": null,
+        "type": "admin_request",
+        "data": null,
+        "createdAt": "2018-10-11T14:06:29.950Z",
+        "updatedAt": "2018-10-11T14:06:29.950Z",
+        "user": {
+          "id": "3dee1006-c5e0-42dc-97f5-774729e571dc",
+          "blocked": false,
+          "displayName": "Eze",
+          "email": "eze.kevin@andela.com",
+          "githubUsername": "kenware",
+          "googleId": "111983208149639253018",
+          "photo": "https://lh4.googleusercontent.com/-zir2MgaM76k/AAAAAAAAAAI/AAAAAAAAAAA/AAN31DU1y8T1ko4cnc0-HNC9bcDPvQ8LPA/s96-c/photo.jpg",
+          "role": "member",
+          "slackId": "123454",
+          "verified": false,
+          "createdAt": "2018-10-09T09:57:12.339Z",
+          "updatedAt": "2018-10-09T09:57:12.339Z"
+        }
+      },
+      {
+        "id": "977a7d2d-b3043a-4669-89d0-46e5151380b2",
+        "userId": "76e999da-31b0-4f5e-ba34-b66bc58b93f1",
+        "teamId": null,
+        "type": "admin_request",
+        "data": null,
+        "createdAt": "2018-10-17T09:39:02.616Z",
+        "updatedAt": "2018-10-17T09:39:02.616Z",
+        "user": {
+          "id": "76e999da-31b0-4f5e-ba34-b66bc58b93f1",
+          "blocked": false,
+          "displayName": "Jacob",
+          "email": "jacob.nouwatin@andela.com",
+          "githubUsername": "nouwatinjacob",
+          "googleId": "107115925180426618809",
+          "photo": "https://lh5.googleusercontent.com/-2Xmwd62r3aw/AAAAAAAAAAI/AAAAAAAAABk/Ich0bYU4tI8/s96-c/photo.jpg",
+          "role": "admin",
+          "slackId": "123456",
+          "verified": false,
+          "createdAt": "2018-10-07T12:11:28.974Z",
+          "updatedAt": "2018-10-07T12:11:28.974Z"
+        }
+      },
+      {
+        "id": "3f78fc72-0635-404d-a44df-f5c87d29bc9a",
+        "userId": "ac568e4b-fdaa-4925-9d48-50fa0c755f7f",
+        "teamId": null,
+        "type": "admin_request",
+        "data": null,
+        "createdAt": "2018-10-16T13:00:30.043Z",
+        "updatedAt": "2018-10-16T13:00:30.043Z",
+        "user": {
+          "id": "ac568e4b-fdaa-4925-9d48-50fa0c755f7f",
+          "blocked": false,
+          "displayName": "Oguejiofor",
+          "email": "oguejiofor.chidiebere@andela.com",
+          "githubUsername": "prof",
+          "googleId": "112154402615555847666",
+          "photo": "https://lh3.googleusercontent.com/-QToLxIFrSmw/AAAAAAAAAAI/AAAAAAAAAAA/AAN31DVd-VxKZmompi6oltuKrQkpbJNxyQ/s96-c/photo.jpg",
+          "role": "member",
+          "slackId": "4354545454",
+          "verified": false,
+          "createdAt": "2018-10-16T12:20:38.914Z",
+          "updatedAt": "2018-10-16T12:20:38.914Z"
+        }
+      },
+      {
+        "id": "87ffd2b5-e894-4312-ae3b-f1060bf386d45",
+        "userId": "3dee1006-c5e0-42dc-97f5-774729e571dc",
+        "teamId": null,
+        "type": "admin_request",
+        "data": null,
+        "createdAt": "2018-10-11T14:06:29.950Z",
+        "updatedAt": "2018-10-11T14:06:29.950Z",
+        "user": {
+          "id": "3dee1006-c5e0-42dc-97f5-774729e571dc",
+          "blocked": false,
+          "displayName": "Eze",
+          "email": "eze.kevin@andela.com",
+          "githubUsername": "kenware",
+          "googleId": "111983208149639253018",
+          "photo": "https://lh4.googleusercontent.com/-zir2MgaM76k/AAAAAAAAAAI/AAAAAAAAAAA/AAN31DU1y8T1ko4cnc0-HNC9bcDPvQ8LPA/s96-c/photo.jpg",
+          "role": "member",
+          "slackId": "123454",
+          "verified": false,
+          "createdAt": "2018-10-09T09:57:12.339Z",
+          "updatedAt": "2018-10-09T09:57:12.339Z"
+        }
+      }
+    ]
+  },
+  "meta": {
+    "pagination": {
+      "limit": 20,
+      "offset": 0,
+      "page": 1,
+      "pages": 1,
+      "pageSize": 20,
+      "total": 4,
+      "current": "http://localhost:8000/v1/requests"
+    }
+  }
+};
+
+export default adminRequests;

--- a/client/src/tests/modules/HOC/withRequests.test.jsx
+++ b/client/src/tests/modules/HOC/withRequests.test.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import withRequests from '../../../modules/HOC/withRequests';
+import requests from '../Admin/mock/mockData';
+
+describe('Test for withRequests HOC', () => {
+  const Component = <p>Ball</p>;
+  const ComponentFromHOC = withRequests(Component, {
+    requests: requests.data.requests,
+    pageTitle: 'Admin Requests'
+  });
+
+  const wrapper = shallow(<ComponentFromHOC />);
+  it("should mount without crashing", () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("should call the event handler when checkbox is main-control", () => {
+    expect(true).toBe(true);
+    const event = {
+      target: {
+        name: 'main-control',
+        checked: false
+      }
+    };
+
+    wrapper.find('[headerText="Admin Requests"]').props().handleChange(event, requests.data.requests[0]);
+
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("should call the event handler when checkbox is not main-control", () => {
+    const event = {
+      target: {
+        name: '',
+        checked: false
+      }
+    };
+
+    wrapper.find('[headerText="Admin Requests"]').props().handleChange(event, requests.data.requests[0]);
+
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/client/src/tests/modules/common/Pagination/index.test.jsx
+++ b/client/src/tests/modules/common/Pagination/index.test.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import RequestPagination from '../../../../modules/common/Pagination';
+
+describe('Test for Pagination component', () => {
+  const WrapperComponent = shallow(<RequestPagination />);
+
+  it('should render properly', () => {
+    expect(WrapperComponent.find('Pagination').length).toBe(1);
+  });
+});
+

--- a/client/styles/base/_settings.scss
+++ b/client/styles/base/_settings.scss
@@ -1,5 +1,6 @@
 // colors
 $red: rgb(247, 104, 104);
+$red-hover: rgb(232, 70, 70);
 $andela-blue: #3359DB;
 $blue: #385cd7;
 $blue-hover: #0e3fdf;

--- a/client/styles/base/_util.scss
+++ b/client/styles/base/_util.scss
@@ -77,6 +77,11 @@
   width: 3rem;
 }
 
+// to allow user input to be selected
+[type="checkbox"] {
+  user-select: all !important;
+}
+
 .custom-form {
   .input-field input[type=text]:focus+label,
   .input-field input[type=number]:focus+label,
@@ -145,6 +150,21 @@
   }
   &:focus {
     background: $blue;
+  }
+}
+
+.admin-btn-margin {
+  margin-right: 2em;
+}
+
+.red-btn {
+  background: $red;
+  color: $white;
+  &:hover {
+    background: $red-hover;
+  }
+  &:focus {
+    background: $red-hover;
   }
 }
 

--- a/client/styles/components/_admin_request.scss
+++ b/client/styles/components/_admin_request.scss
@@ -1,0 +1,34 @@
+.request-container {
+  color: $blue;
+  text-align: center;
+  margin-top: 50px;
+  position: relative;
+
+    .hr-top {
+      width: 80%;
+      background-color: $blue;
+      border: 1px solid;
+    }
+
+    .request-checkbox-container {
+      width: 85%;
+      margin: 5em auto;
+      position: relative;
+      text-align: center;
+
+      form {
+        text-align: left;
+        width: 70%;
+        margin: 3em auto;
+
+        span {
+          font-size: 1.5rem;
+          color: rgba(0,0,0,.95);
+        }
+      }
+    }
+
+    .admin-btn-holder {
+      margin: 3em auto;
+    }
+}

--- a/client/styles/components/_navbar.scss
+++ b/client/styles/components/_navbar.scss
@@ -82,6 +82,19 @@
 .notif-container {
   position: relative;
 }
+.notif-badge {
+  height: 22px !important;
+    width: 22px !important;
+    min-width: 0 !important;
+    color: white !important;
+    position: absolute;
+    left: 25px;
+    text-align: center;
+    top: 7px;
+    padding: 0 !important;
+    border-radius: 10px !important;
+    background: rgb(240, 1, 1) !important;
+}
 
 .tabs.tabs-transparent .indicator {
   background: $blue;

--- a/client/styles/styles.scss
+++ b/client/styles/styles.scss
@@ -10,3 +10,4 @@
 @import './components/form';
 @import './components/teams';
 @import './components/_create_team';
+@import './components/_admin_request';


### PR DESCRIPTION
#### What does this PR do?
  	- add badge on the notification bell on navbar
	- add link to the notification icon
	- add route for the page
	- create checkbox, admin request and checkbox holder  component
	- create admin_request sass file
	- create HOC for requests
	- add unit tests for the components
	- add props-type validation

#### Description of Task to be completed?
  - Design UI for page showing all admin request

#### How should this be manually tested?
- Login as an admin to the [review app](https://ghoulies-taps-client.herokuapp.com/) 
- If there are requests, it will be displayed on the notification icon
- Click on the icon
- You'll be directed to the admin requests page.

#### Any background context you want to provide?
- When a member requires admin privilege in the application, the number of requests made is shown
on the notification icon which will help the admin access the requests

#### What are the relevant pivotal tracker stories?
Story [#161223150](https://www.pivotaltracker.com/story/show/161223150)

#### Screenshots (if appropriate)
<img width="770" alt="screen shot 2018-10-18 at 10 00 16 am" src="https://user-images.githubusercontent.com/12391886/47177716-1f6de280-d311-11e8-8b55-8afc6178d833.png">


#### Questions:
N/A