### PR TITLE
#161246353: team lead should accept request 

### DIFF
--- a/client/src/modules/Admin/components/AdminRequest.jsx
+++ b/client/src/modules/Admin/components/AdminRequest.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 // components
-import withRequests from '../../HOC/withRequests';
+import { withRequests } from '../../HOC/withRequests';
 import RequestHolder from './RequestHolder';
 import RequestPagination from '../../common/Pagination';
 import { loadRequests } from '../../../redux/actions/requests';
@@ -39,14 +39,15 @@ export const Request = ({
 Request.propTypes = {
   headerText: PropTypes.string.isRequired,
   handleChange: PropTypes.func.isRequired,
-  requests: PropTypes.array,
+  requests: PropTypes.array.isRequired,
   checkedAll: PropTypes.bool.isRequired,
-  pagination: PropTypes.object,
+  pagination: PropTypes.object.isRequired,
   handlePaginationClick: PropTypes.func.isRequired
 };
 
 export const AdminRequests = withRequests(Request, {
-  pageTitle: 'Admin Requests'
+  pageTitle: 'Admin Requests',
+  requestType: 'admin_request'
 });
 
 

--- a/client/src/modules/Admin/components/RequestCheckbox.jsx
+++ b/client/src/modules/Admin/components/RequestCheckbox.jsx
@@ -2,12 +2,10 @@ import React from 'react';
 
 const RequestCheckbox = ({
   handleChange,
-  checkOne,
-  requests = [],
-  checkedAll
+  requests = []
 }) => {
   const Requests = requests.map((request, index) => (
-    <p key={request.id}>
+    <p key={request.id} id="request-checkbox">
       <label htmlFor={request.id}>
         <input
           name={request.id}
@@ -17,7 +15,11 @@ const RequestCheckbox = ({
           onChange={(e) => handleChange(e, request)}
           checked={request.checked}
         />
-        <span>{`${request.user.displayName} < ${request.user.email} >`}</span>
+        <span>{`${request.user.displayName} < ${request.user.email} >`}
+          <label className="team-type-label ">Requested to join as a  <b>{request.data}</b>
+          </label>
+        </span>
+
       </label>
     </p>));
 

--- a/client/src/modules/HOC/withRequests.jsx
+++ b/client/src/modules/HOC/withRequests.jsx
@@ -1,7 +1,5 @@
 import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
-import { loadRequests } from '../../redux/actions/requests';
 
 // components
 import Navbar from '../common/Navbar';
@@ -22,7 +20,7 @@ export const withRequests = (WrappedComponent, data) => {
 
     componentDidMount() {
       const { loadRequests } = this.props;
-      loadRequests('admin_request', 20);
+      loadRequests(data.requestType, 20);
     }
 
     componentWillReceiveProps(nextProps) {
@@ -85,7 +83,8 @@ export const withRequests = (WrappedComponent, data) => {
       const { pagination } = this.state;
       const { loadRequests } = this.props;
       const nextOffset = (activePage - 1) * pagination.limit;
-      loadRequests('admin_request', '', nextOffset);
+
+      loadRequests(data.requestType, '', nextOffset);
     }
 
     render() {
@@ -95,7 +94,7 @@ export const withRequests = (WrappedComponent, data) => {
       } = this.state;
       return (
         <Fragment>
-          <Navbar />
+          {!data.hideNav ? <Navbar /> : null}
           <WrappedComponent
             headerText={data.pageTitle}
             handleChange={this.handleInputChange}

--- a/client/src/modules/Teams/components/JoinTeamRequests.jsx
+++ b/client/src/modules/Teams/components/JoinTeamRequests.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { connect } from 'react-redux';
+// components
+import { withRequests } from '../../HOC/withRequests';
+import { Request } from '../../Admin/components/AdminRequest';
+import { loadRequests } from '../../../redux/actions/requests';
+
+
+export const JoinTeamRequests = withRequests(Request, {
+  pageTitle: 'Join Team Requests',
+  hideNav: true,
+  requestType: 'member_request'
+});
+
+
+export const mapStateToProps = ({ requestsReducer }) => ({
+  loadedRequests: requestsReducer.loadedRequests
+});
+
+export default connect(mapStateToProps, { loadRequests })(JoinTeamRequests);

--- a/client/src/modules/Teams/components/Member.jsx
+++ b/client/src/modules/Teams/components/Member.jsx
@@ -7,6 +7,7 @@ import autoBind from 'auto-bind';
 import Gallery from './Gallery';
 import InviteMembers from './InviteMembers';
 import ShareLinkComponent from './ShareLink';
+import JoinTeamRequestsComponent from "./JoinTeamRequests";
 
 export class Member extends Component {
   constructor(props) {
@@ -21,10 +22,13 @@ export class Member extends Component {
       return members.map(member => (
         <Gallery data={member} key={member.user.id} />
       ));
-      break;
+
     case 'invite members':
       return <InviteMembers addMember={addNewMember} />;
-      break;
+
+    case 'confirm requests':
+      return <JoinTeamRequestsComponent />;
+
 
     case 'share link':
       return <ShareLinkComponent teamId={teamId} />;
@@ -121,6 +125,17 @@ export class Member extends Component {
                 )
                 }
                   
+                { this.checkTeamLead() && (
+                  <li
+                    className="nav-link"
+                    onClick={event => chooseContent(event, 'confirm requests')}
+                  >
+                    <i className="material-icons left nav-icons">person_outline</i>
+                    <span className="nav-icons">Confirm Requests</span>
+                  </li>
+                )
+                }
+                
                 </ul>
               </div>
             )}

--- a/client/src/modules/Teams/container/Join.jsx
+++ b/client/src/modules/Teams/container/Join.jsx
@@ -17,7 +17,8 @@ export class Join extends Component {
     const decoded = jwtDecode(this.props.match.params.joinToken);
     this.setState({
       teamId: decoded.teamId,
-      teamName: decoded.teamName
+      teamName: decoded.teamName,
+      role: decoded.role
     });
     this.joinTeam = this.joinTeam.bind(this);
   }
@@ -32,7 +33,7 @@ export class Join extends Component {
       userId: localStorage.getItem('userId'),
       teamId: this.state.teamId,
       type: 'member_request',
-      data: 'developer'
+      data: this.state.role
     };
     this.props.makeRequest(requestData);
     this.props.history.push('/teams');

--- a/client/src/tests/modules/teams/components/JoinTeamRequests.test.jsx
+++ b/client/src/tests/modules/teams/components/JoinTeamRequests.test.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { mapStateToProps } from '../../../../modules/Teams/components/JoinTeamRequests';
+
+
+describe('Testing JoinTeamRequests', () => {
+  it('mapStateToProps should map the state correctly', () => {
+    const expectedLoadedRequests = ['value-1', 'value-2'];
+    const mockState = {
+      requestsReducer: { loadedRequests: expectedLoadedRequests }
+    };
+
+    const mappedProps = mapStateToProps(mockState);
+
+    expect(mappedProps.loadedRequests)
+      .toBe(expectedLoadedRequests);
+  });
+});

--- a/client/styles/components/_request_checkbox.scss
+++ b/client/styles/components/_request_checkbox.scss
@@ -1,0 +1,12 @@
+#request-checkbox {
+  $label-text-color: #f86767;
+
+
+  .team-type-label {
+    color: $label-text-color;
+    display: block;
+    font-size: 12px;
+    min-width: 44%;
+    padding: 0 6px;
+  }
+}

--- a/client/styles/styles.scss
+++ b/client/styles/styles.scss
@@ -12,3 +12,5 @@
 @import './components/_create_team';
 @import './components/_admin_request';
 @import './components//invite_form';
+@import "./components/request_checkbox";
+


### PR DESCRIPTION
#### What does this PR do?
- add mockup for team lead view requests page

#### Description of Task to be completed?
- team lead should be able to view the requests that have been made

#### How should this be manually tested?
- select a team where you are the team lead from the home page
- click on the add user button on the sidebar
- you should see the list of requests that have been made

#### Any background context you want to provide?
- the data shown in this PR is retrieved via `API` calls but the `accept button` is  currently not functional because the action have not yet been created

#### What are the relevant pivotal tracker stories?
[161246353](https://www.pivotaltracker.com/story/show/161246353)

#### Screenshots or gifs (if appropriate)
<img width="1440" alt="screenshot 2018-10-24 at 4 15 39 pm" src="https://user-images.githubusercontent.com/38565349/47441459-17e28980-d7a8-11e8-863d-9b0ee6623f76.png">
<img width="1440" alt="screenshot 2018-10-24 at 4 15 36 pm" src="https://user-images.githubusercontent.com/38565349/47441461-187b2000-d7a8-11e8-84ef-914de8a2bfc4.png">

#### Questions:
- none
